### PR TITLE
Update version number to match react's

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019-present Preact Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# @preact/compat - alias package
+
+This package is intended to be used to resolve `react` to `preact/compat` via built-in features in npm, which requires a separate package to be used. Therefore this package just re-exports `preact/compat` as is.
+
+To learn more about Preact itself, check out the main repo: https://github.com/preactjs/preact
+
+## Usage
+
+Run:
+
+```bash
+npm install react@npm:@preact/compat react-dom@npm:@preact/compat
+```
+
+See the [npm docs](https://docs.npmjs.com/cli/v7/commands/npm-install) for more information about aliased installs.
+
+## License
+
+MIT, see the [LICENSE](./LICENSE) file.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@preact/compat",
-  "version": "0.0.3",
+  "version": "16.9.0",
   "description": "Alias of preact/compat",
   "main": "index.js",
   "module": "index.module.js",


### PR DESCRIPTION
Turns out that npm compares the version number of aliased packages and `0.0.4` doesn't hold a candle against `16.9.0` :grimacing:

Took the time to add a tiny readme to explain what this package is and add a license file.

Fixes https://github.com/preactjs/next-plugin-preact/issues/37