### PR TITLE
Upgrade version to 17.0.2 for next 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@preact/compat",
-  "version": "16.9.0",
+  "version": "17.0.2",
   "description": "Alias of preact/compat",
   "main": "index.js",
   "module": "index.module.js",


### PR DESCRIPTION
Turns out next 11 requires an even higher version `17.0.2` at a minimum.

This is a follow-up to #2 