### PR TITLE
Fix: remove server.browser.js in favor of export mapping to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
       "require": "./index.js"
     },
     "./server": {
-      "browser": "./server.browser.js",
+      "module": "./server.mjs",
+      "import": "./server.mjs",
+      "require": "./server.js"
+    },
+    "./server.browser": {
       "module": "./server.mjs",
       "import": "./server.mjs",
       "require": "./server.js"

--- a/server.browser.js
+++ b/server.browser.js
@@ -1,1 +1,0 @@
-export * from 'preact/compat/server';


### PR DESCRIPTION
The `browser` subpath is for browser/client bundles. The `server.browser` path from Next.js is [requested in Node](https://github.com/vercel/next.js/blob/3e5b0253e4b0d0d32cee1770cd57a95352bf76c9/packages/next/server/render.tsx#L92).

Adding the corresponding export mapping to the same `server` file addresses the [issue](https://github.com/preactjs/next-plugin-preact/issues/60) in Next.js 12.1.6.