### PR TITLE
make the structure the same as the 'preact/compat' directory

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('preact/compat/client');

--- a/client.mjs
+++ b/client.mjs
@@ -1,0 +1,1 @@
+export * from 'preact/compat/client';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "module": "./jsx-runtime.mjs",
       "import": "./jsx-runtime.mjs",
       "require": "./jsx-runtime.js"
+    },
+    "./test-utils": {
+      "module": "./test-utils.mjs",
+      "import": "./test-utils.mjs",
+      "require": "./test-utils.js"
     }
   },
   "repository": "preactjs/compat-alias-package",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
       "module": "./test-utils.mjs",
       "import": "./test-utils.mjs",
       "require": "./test-utils.js"
+    },
+    "./client": {
+      "module": "./client.mjs",
+      "import": "./client.mjs",
+      "require": "./client.js"
     }
   },
   "repository": "preactjs/compat-alias-package",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "module": "./scheduler.mjs",
       "import": "./scheduler.mjs",
       "require": "./scheduler.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "repository": "preactjs/compat-alias-package",
   "author": "Preact Team <team@preactjs.com>",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
       "module": "./client.mjs",
       "import": "./client.mjs",
       "require": "./client.js"
+    },
+    "./scheduler": {
+      "module": "./scheduler.mjs",
+      "import": "./scheduler.mjs",
+      "require": "./scheduler.js"
     }
   },
   "repository": "preactjs/compat-alias-package",

--- a/scheduler.js
+++ b/scheduler.js
@@ -1,0 +1,1 @@
+module.exports = require('preact/compat/scheduler');

--- a/scheduler.mjs
+++ b/scheduler.mjs
@@ -1,0 +1,1 @@
+export * from 'preact/compat/scheduler';

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,0 +1,1 @@
+module.exports = require('preact/test-utils');

--- a/test-utils.mjs
+++ b/test-utils.mjs
@@ -1,0 +1,1 @@
+export * from 'preact/test-utils';


### PR DESCRIPTION
When testing, or implementing with the React v18 API, there are missing test-utils.js and client.js.

In this PR, make the structure the same as the 'preact/compat' directory.