### PR TITLE
Upgrade version to 18.2.0 for Next.js 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@preact/compat",
-  "version": "17.1.2",
+  "version": "18.2.0",
   "description": "Alias of preact/compat",
   "main": "./index.js",
   "module": "./index.mjs",
@@ -45,6 +45,6 @@
     "preact": "*"
   },
   "devDependencies": {
-    "preact": "^10.5.15"
+    "preact": "^10.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "preact": "*"
   },
   "devDependencies": {
-    "preact": "^10.9.0"
+    "preact": "^10.11.2"
   }
 }


### PR DESCRIPTION
Next.js 13 bumped the minimum React version from 17.0.2 to [18.2.0](https://nextjs.org/docs/upgrading).

x-ref: https://github.com/vercel/next.js/issues/42530