### PR TITLE
fix: default export mismatch

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1,2 +1,1 @@
 export * from 'preact/compat/server';
-export { default } from 'preact/compat/server';


### PR DESCRIPTION
Fixes:
``
Build failed with 1 error:
node_modules/.pnpm/@preact+compat@17.1.2_preact@10.11.3/node_modules/@preact/compat/server.mjs:2:9: ERROR: No matching export in "node_modules/.pnpm/preact@10.11.3/node_modules/preact/compat/server.mjs" for import "default"
``