### PR TITLE
Bump version for React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@preact/compat",
-  "version": "17.1.2",
+  "version": "18.3.1",
   "description": "Alias of preact/compat",
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
NPM complains when using this alias with libraries which require a peer dependency on React 18