### PR TITLE
18.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@preact/compat",
-  "version": "17.1.2",
+  "version": "18.3.1",
   "description": "Alias of preact/compat",
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
Should we bump https://github.com/preactjs/preact/blob/main/compat/src/index.js#L38 as well or should we trust that folks don't check this and only do it for the package managers?

Resolves https://github.com/preactjs/preact/issues/4441